### PR TITLE
feat(model): add `integration_type` to audit log entries

### DIFF
--- a/twilight-model/src/guild/audit_log/optional_entry_info.rs
+++ b/twilight-model/src/guild/audit_log/optional_entry_info.rs
@@ -1,6 +1,9 @@
-use crate::id::{
-    marker::{ChannelMarker, GenericMarker, MessageMarker},
-    Id,
+use crate::{
+    guild::GuildIntegrationType,
+    id::{
+        marker::{ChannelMarker, GenericMarker, MessageMarker},
+        Id,
+    },
 };
 use serde::{Deserialize, Serialize};
 
@@ -99,6 +102,16 @@ pub struct AuditLogOptionalEntryInfo {
     /// [`AuditLogEventType::ChannelOverwriteDelete`]: super::AuditLogEventType::ChannelOverwriteDelete
     /// [`AuditLogEventType::ChannelOverwriteUpdate`]: super::AuditLogEventType::ChannelOverwriteUpdate
     pub id: Option<Id<GenericMarker>>,
+    /// Type of integration which performed the action.
+    ///
+    /// The following events have this option:
+    ///
+    /// - [`AuditLogEventType::MemberKick`]
+    /// - [`AuditLogEventType::MemberRoleUpdate`]
+    ///
+    /// [`AuditLogEventType::MemberKick`]: super::AuditLogEventType::MemberKick
+    /// [`AuditLogEventType::MemberRoleUpdate`]: super::AuditLogEventType::MemberRoleUpdate
+    pub integration_type: Option<GuildIntegrationType>,
     /// Type of overwritten entity.
     ///
     /// The following events have this option:

--- a/twilight-model/src/guild/integration_type.rs
+++ b/twilight-model/src/guild/integration_type.rs
@@ -18,6 +18,8 @@ pub enum GuildIntegrationType {
     Twitch,
     /// Integration is a YouTube connection.
     YouTube,
+    /// Integration is a Guild Subscription.
+    GuildSubscription,
     /// Variant value is unknown to the library.
     Unknown(String),
 }
@@ -28,6 +30,7 @@ impl From<GuildIntegrationType> for Cow<'static, str> {
             GuildIntegrationType::Discord => "discord".into(),
             GuildIntegrationType::Twitch => "twitch".into(),
             GuildIntegrationType::YouTube => "youtube".into(),
+            GuildIntegrationType::GuildSubscription => "guild_subscription".into(),
             GuildIntegrationType::Unknown(unknown) => unknown.into(),
         }
     }
@@ -39,6 +42,7 @@ impl From<String> for GuildIntegrationType {
             "discord" => Self::Discord,
             "twitch" => Self::Twitch,
             "youtube" => Self::YouTube,
+            "guild_subscription" => Self::GuildSubscription,
             _ => Self::Unknown(value),
         }
     }
@@ -55,6 +59,10 @@ mod tests {
             (GuildIntegrationType::Discord, "discord"),
             (GuildIntegrationType::Twitch, "twitch"),
             (GuildIntegrationType::YouTube, "youtube"),
+            (
+                GuildIntegrationType::GuildSubscription,
+                "guild_subscription",
+            ),
         ];
 
         for (integration_type, value) in MAP {


### PR DESCRIPTION
Ref:
- https://github.com/discord/discord-api-docs/pull/6367

This PR also adds a missing `guild_subscription` variant to `GuildIntegrationType`